### PR TITLE
Recognise PATCH as a valid HTTP verb.

### DIFF
--- a/lib/HTTP/Server/Simple.pm
+++ b/lib/HTTP/Server/Simple.pm
@@ -709,7 +709,7 @@ and C<DELETE>.
 sub valid_http_method {
     my $self   = shift;
     my $method = shift or return 0;
-    $return $method =~ /^(?:GET|POST|HEAD|PUT|PATCH|DELETE)$/;
+    return $method =~ /^(?:GET|POST|HEAD|PUT|PATCH|DELETE)$/;
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
This is defined in RFC5789: http://tools.ietf.org/html/rfc5789

This is in active use by GitHub's v3 API, among others.

As a quick overview for anyone unfamilar with PATCH, it's basically a
partial-PUT, passing only the changes - for instance, let's say you wanted to
update a customer's contact email address, you might send a PATCH request to
`/customer/42/contactdetails` with a JSON payload describing just the parts
which have changed, for instance `{ email: 'bob@example.com' }`.
