### PR TITLE
Recognize OPTIONS as a valid HTTP method

### DIFF
--- a/lib/HTTP/Server/Simple.pm
+++ b/lib/HTTP/Server/Simple.pm
@@ -757,15 +757,15 @@ sub bad_request {
 
 Given a candidate HTTP method in $method, determine if it is valid.
 Override if, for example, you'd like to do some WebDAV.  The default
-implementation only accepts C<GET>, C<POST>, C<HEAD>, C<PUT>, C<PATCH>
-and C<DELETE>.
+implementation only accepts C<GET>, C<POST>, C<HEAD>, C<PUT>, C<PATCH>,
+C<DELETE> and C<OPTIONS>.
 
 =cut 
 
 sub valid_http_method {
     my $self   = shift;
     my $method = shift or return 0;
-    return $method =~ /^(?:GET|POST|HEAD|PUT|PATCH|DELETE)$/;
+    return $method =~ /^(?:GET|POST|HEAD|PUT|PATCH|DELETE|OPTIONS)$/;
 }
 
 =head1 AUTHOR

--- a/t/04cgi.t
+++ b/t/04cgi.t
@@ -37,7 +37,7 @@ if ($^O eq 'freebsd' && `sysctl -n security.jail.jailed` == 1) {
     plan tests => 55;
 }
 else {
-    plan tests => 60;
+    plan tests => 61;
 }
 
 {
@@ -57,6 +57,7 @@ else {
       [["PUT / HTTP/1.1","Content-Length: 0",""], '/NOFILE/', '[PUT] no file'],
       [["DELETE / HTTP/1.1",""], '/NOFILE/', '[DELETE] no file'],
       [["PATCH / HTTP/1.1","Content-Length: 0",""], '/NOFILE/', '[PATCH] no file'],
+      [["OPTIONS / HTTP/1.1","Content-Length: 0",""], '/NOFILE/', '[OPTIONS] no file'],
   );
   foreach my $message_test (@message_tests) {
     my ($message, $expected, $description) = @$message_test;


### PR DESCRIPTION
As noted in <https://rt.cpan.org/Public/Bug/Display.html?id=82740>,
OPTIONS requests are required for non-trivial cross-site requests.
Dancer uses HTTP::Server::Simple and therefore cannot support a common
type of AJAX/REST request without this change.

Signed-off-by: James McCoy <vega.james@gmail.com>