### PR TITLE
Fix test count in freebsd jails

### DIFF
--- a/t/04cgi.t
+++ b/t/04cgi.t
@@ -34,7 +34,7 @@ my %envvars=(
 if ($^O eq 'freebsd' && `sysctl -n security.jail.jailed` == 1) {
     delete @methods{qw(url server_name)};
     delete @envvars{qw(SERVER_URL SERVER_NAME REMOTE_ADDR)};
-    plan tests => 55;
+    plan tests => 45;
 }
 else {
     plan tests => 60;


### PR DESCRIPTION
Tests added in d755a1cd and 140c8684 assumed a stepped 5 test difference
on freebsd without accounting for the fact that each of the 5 skipped
methods/environments are actually tested 3 times for a total current
diff of 15.

Reported in RT#103794