### PR TITLE
Use Net::EmptyPort

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,6 +8,9 @@ requires(
     'Test::More'  => 0,
     CGI         => 0,
 );
+test_requires(
+    'Net::EmptyPort' => 0,
+);
 
 repository('https://github.com/bestpractical/http-server-simple');
 WriteAll( sign => 1);

--- a/lib/HTTP/Server/Simple.pm
+++ b/lib/HTTP/Server/Simple.pm
@@ -127,8 +127,8 @@ could kill the server.
 =head2 HTTP::Server::Simple->new($port, $family)
 
 API call to start a new server.  Does not actually start listening
-until you call C<-E<gt>run()>.  If omitted, C<$port> defaults to 8080,
-and C<$family> defaults to L<Socket::AF_INET>.
+until you call C<< $server->run() >>.  If omitted, C<$port> defaults 
+to 8080, and C<$family> defaults to L<Socket::AF_INET>.
 The alternative domain is L<Socket::AF_INET6>.
 
 =cut
@@ -384,8 +384,8 @@ sub _process_request {
 
         $self->stdio_handle(*STDIN) unless $self->stdio_handle;
 
- # Default to unencoded, raw data out.
- # if you're sending utf8 and latin1 data mixed, you may need to override this
+        # Default to unencoded, raw data out.
+        # if you're sending utf8 and latin1 data mixed, you may need to override this
         binmode STDIN,  ':raw';
         binmode STDOUT, ':raw';
 
@@ -665,7 +665,7 @@ sub parse_request {
 =head2 parse_headers
 
 Parses incoming HTTP headers from STDIN, and returns an arrayref of
-C<(header =E<gt> value)> pairs.  See L</headers> for possibilities on
+C<< (header => value) >> pairs.  See L</headers> for possibilities on
 how to inspect headers.
 
 =cut

--- a/t/01live.t
+++ b/t/01live.t
@@ -2,12 +2,13 @@
 
 use Socket;
 use Test::More;
+use Net::EmptyPort;
 use strict;
 
 # This script assumes that `localhost' will resolve to a local IP
 # address that may be bound to,
 
-my $PORT = 40000 + int(rand(10000));
+my $PORT = empty_port();
 my $RUN_IPV6 = eval {
 	my $ipv6_host = get_localhost(AF_INET6);
 	socket my $sockh, Socket::PF_INET6(), SOCK_STREAM, 0 or die "Cannot socket(PF_INET6) - $!";

--- a/t/04cgi.t
+++ b/t/04cgi.t
@@ -2,9 +2,10 @@
 
 use Test::More;
 use Socket;
+use Net::EmptyPort;
 use strict;
 
-my $PORT = 40000 + int(rand(10000));
+my $PORT = empty_port();
 
 my $host = gethostbyaddr(inet_aton('localhost'), AF_INET);
 


### PR DESCRIPTION
Hi, Vincent et al

I got assigned HTTP::Server::Simple as PRC November module. I was looking in RT for some open tickets, and found someone complaining of using random ports on tests [https://rt.cpan.org/Ticket/Display.html?id=82748]. So, I added a dependency on Net::EmptyPort. I know dependencies can be bad, but the module seems quite self contained.

I also changed  little the POD in order to remove, when possible, the use of E<gt> as its legibility is not very good.

Hope you find this PR useful.
Best,
Alberto