### PR TITLE
Document the minimal server listening socket filehandle name

### DIFF
--- a/lib/HTTP/Server/Simple.pm
+++ b/lib/HTTP/Server/Simple.pm
@@ -312,6 +312,9 @@ User-overridable method. If you set it to a L<Net::Server> subclass,
 that subclass is used for the C<run> method.  Otherwise, a minimal
 implementation is used as default.
 
+With the minimal implementation, the master listening socket
+filehandle is C<HTTP::Server::Simple::HTTPDaemon>.
+
 =cut
 
 sub net_server {undef}


### PR DESCRIPTION
Knowing this is useful in post_setup_hook, or maybe if
one wants to override setup_hook without reimplementing run (ie, the
code in _default_run).

For example, if one wants HTTP::Server::Simple to bind to any free
port, one can override port to specify 0, so that the OS chooses a
free port.  But one then needs to get the port number out somehow and
the obvious method is calling getsockname on the filehandle.

So document this.  It seems unlikely that the minimal implementation
will want or need to change this.

Signed-off-by: Ian Jackson <ijackson@chiark.greenend.org.uk>